### PR TITLE
refactor: ScrollSpy 컴포넌트의 useEffect 의존성 배열 수정

### DIFF
--- a/src/app/PageClient.tsx
+++ b/src/app/PageClient.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useRef, useState } from "react";
 import Tab from "@/components/base/Tab";
 import ProductsInfo from "@/components/products/ProductsInfo";
 import ProductsPurchaseInfo from "@/components/products/ProductsPurchaseInfo";
@@ -8,26 +8,19 @@ import ProductsReview from "@/components/products/ProductsReview";
 import ScrollSpy from "@/components/headlessui/ScrollSpy";
 import { useRouter } from "next/navigation";
 const PageClient = () => {
-  const sectionRefs = [
-    useRef<HTMLElement>(null),
-    useRef<HTMLElement>(null),
-    useRef<HTMLElement>(null),
-    useRef<HTMLElement>(null),
-  ];
+  const sectionRefs = useRef<(HTMLElement | null)[]>([]);
   const [currentTab, setCurrentTab] = useState(0);
   const router = useRouter();
 
   const handleSetActive = (index: number) => {
-    if (currentTab !== index) {
-      setCurrentTab(index);
-      router.replace(`#${sectionRefs[index].current?.id}` ?? "/");
-    }
+    setCurrentTab(index);
+    // router.replace(`#${sectionRefs.current[index]?.id}` ?? "/");
   };
 
   const handleActiveTabClick = (index: number) => {
-    if (sectionRefs[index].current) {
-      sectionRefs[index].current?.scrollIntoView();
-      router.push(`#${sectionRefs[index].current?.id}` ?? "/");
+    if (sectionRefs.current[index]) {
+      sectionRefs.current[index]?.scrollIntoView();
+      router.push(`#${sectionRefs.current[index]?.id}` ?? "/");
     }
     setCurrentTab(index);
   };
@@ -48,16 +41,22 @@ const PageClient = () => {
         />
       </div>
       <div>
-        <section id="productInfo" ref={sectionRefs[0]}>
+        <section id="productInfo" ref={(el) => (sectionRefs.current[0] = el)}>
           <ProductsInfo />
         </section>
-        <section id="productsPurchaseInfo" ref={sectionRefs[1]}>
+        <section
+          id="productsPurchaseInfo"
+          ref={(el) => (sectionRefs.current[1] = el)}
+        >
           <ProductsPurchaseInfo />
         </section>
-        <section id="productsQnA" ref={sectionRefs[2]}>
+        <section id="productsQnA" ref={(el) => (sectionRefs.current[2] = el)}>
           <ProductsQnA />
         </section>
-        <section id="productsReview" ref={sectionRefs[3]}>
+        <section
+          id="productsReview"
+          ref={(el) => (sectionRefs.current[3] = el)}
+        >
           <ProductsReview />
         </section>
       </div>

--- a/src/components/headlessui/ScrollSpy.tsx
+++ b/src/components/headlessui/ScrollSpy.tsx
@@ -1,9 +1,9 @@
 "use client";
-import React, { useEffect, useRef } from "react";
+import React, { useEffect } from "react";
 
 interface Props {
   setActiveTab: (index: number) => void;
-  sectionRefs: React.RefObject<HTMLElement>[];
+  sectionRefs: React.MutableRefObject<(HTMLElement | null)[]>;
 }
 
 const ScrollSpy = ({ setActiveTab, sectionRefs }: Props) => {
@@ -12,8 +12,8 @@ const ScrollSpy = ({ setActiveTab, sectionRefs }: Props) => {
       (entries) => {
         entries.forEach((entry) => {
           if (entry.isIntersecting) {
-            const index = sectionRefs.findIndex(
-              ($el) => $el.current === entry.target
+            const index = sectionRefs.current.findIndex(
+              ($el) => $el === entry.target
             );
             setActiveTab(index);
           }
@@ -21,9 +21,9 @@ const ScrollSpy = ({ setActiveTab, sectionRefs }: Props) => {
       },
       { threshold: 0.9 }
     );
-    sectionRefs.forEach((section) => {
-      if (section.current) {
-        observer.observe(section.current);
+    sectionRefs.current.forEach((section) => {
+      if (section) {
+        observer.observe(section);
       }
     });
     return () => {


### PR DESCRIPTION
기존 문제점 : ref들을 일반 지역변수로 관리 해서 PageClient 쪽 컴포넌트의 리렌더링 될 때마다 sectionRefs 변수의 주소값이 바뀜. 그로 인해 ScrollSpy컴포넌트 useEffect쪽의 의존성 배열주소가 PageClient의 리렌더링 마다 변해서 지속적으로 불필요하게 호출 됐었음.

해결책 : sectionRefs변수를 useRef 하나로 관리하게 변경. ref 객체는 컴포넌트가 리렌더링 되어도 같은 객체를 가리키게 되므로 ScrollSpy 컴포넌트의 useEffect가 불필요하게 호출되는 현상이 사라짐